### PR TITLE
Switch API to SQL-backed storage and document AWS deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+.env
+.venv/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Chromosome 21 Gene API
+
+A RESTful FastAPI service for exploring Ensembl Chromosome 21 gene metadata. The
+service stores its data in a SQLite database that is automatically seeded from
+the provided mart export on startup.
+
+## Features
+
+- RESTful endpoints with pagination and filtering for gene metadata.
+- SQLite persistence managed via SQLAlchemy.
+- Ready-to-run locally with Uvicorn.
+- AWS Lambda entrypoint via Mangum for serverless deployments.
+
+## Getting started
+
+### Prerequisites
+
+- Python 3.10+
+- `pip`
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running locally
+
+```bash
+uvicorn main:app --reload
+```
+
+The SQLite database (`chromosome21.sqlite3`) is created in the project root on
+first run. The API documentation is available at `http://127.0.0.1:8000/docs`.
+
+### Configuration
+
+Set the `DATABASE_URL` environment variable to use an alternative database
+connection (for example, an Amazon Aurora cluster). When omitted, the service
+defaults to the bundled SQLite database file.
+
+## REST API
+
+| Method | Endpoint                 | Description                                          |
+| ------ | ------------------------ | ---------------------------------------------------- |
+| GET    | `/`                      | Health and welcome message.                          |
+| GET    | `/genes`                 | Paginated gene list with filter/search parameters.   |
+| GET    | `/genes/{gene_stable_id}`| Retrieve a gene by its Ensembl stable identifier.    |
+| GET    | `/genes/by-name/{name}`  | Retrieve the first gene matching the given symbol.   |
+
+### Query parameters
+
+- `page` / `page_size`: standard pagination controls.
+- `chromosome`: filter by chromosome/scaffold identifier.
+- `gene_type`: filter by the reported gene type.
+- `search`: case-insensitive search across gene names and descriptions.
+
+## AWS deployment
+
+This project ships with an AWS Lambda handler (`aws_lambda.py`). For a
+production-ready deployment that follows AWS best practices, including
+Infrastructure as Code, CI/CD automation, observability, and security
+considerations, see [docs/aws-deployment.md](docs/aws-deployment.md).

--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -2,12 +2,12 @@
 
 from mangum import Mangum
 
-from main import app, load_genes
+from database import init_db
+from main import app
 
-
-# Warm the pandas dataset cache during cold starts so the first request served
+# Warm the SQLite dataset cache during cold starts so the first request served
 # by Lambda is fast.
-load_genes()
+init_db()
 
 # ``lifespan="auto"`` ensures FastAPI startup/shutdown events run correctly in
 # the Lambda runtime managed by Mangum.

--- a/database.py
+++ b/database.py
@@ -1,0 +1,112 @@
+"""Database setup and seeding utilities for the Chromosome 21 Gene API."""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_FILE = BASE_DIR / "mart_export(3).txt"
+DATABASE_FILE = BASE_DIR / "chromosome21.sqlite3"
+DATABASE_URL = os.getenv("DATABASE_URL", f"sqlite:///{DATABASE_FILE}")
+IS_SQLITE = DATABASE_URL.startswith("sqlite")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if IS_SQLITE else {},
+    future=True,
+    echo=False,
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+Base = declarative_base()
+
+
+class Gene(Base):
+    """SQLAlchemy model mapping the mart export dataset."""
+
+    __tablename__ = "genes"
+
+    gene_stable_id = Column(String, primary_key=True, index=True)
+    gene_name = Column(String, index=True, nullable=True)
+    gene_description = Column(String, nullable=True)
+    chromosome = Column(String, index=True, nullable=True)
+    gene_start = Column(Integer, nullable=True)
+    gene_end = Column(Integer, nullable=True)
+    strand = Column(Integer, nullable=True)
+    gene_type = Column(String, index=True, nullable=True)
+
+
+def _parse_int(value: Optional[str]) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _clean_str(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _load_dataset() -> Iterable[Gene]:
+    if not DATA_FILE.exists():
+        return []
+
+    with DATA_FILE.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            stable_id = (row.get("Gene stable ID") or "").strip()
+            if not stable_id:
+                # Skip rows missing a stable identifier because they cannot be queried later.
+                continue
+
+            yield Gene(
+                gene_stable_id=stable_id,
+                gene_name=_clean_str(row.get("Gene name")),
+                gene_description=_clean_str(row.get("Gene description")),
+                chromosome=_clean_str(row.get("Chromosome/scaffold name")),
+                gene_start=_parse_int(row.get("Gene start (bp)")),
+                gene_end=_parse_int(row.get("Gene end (bp)")),
+                strand=_parse_int(row.get("Strand")),
+                gene_type=_clean_str(row.get("Gene type")),
+            )
+
+
+def init_db() -> None:
+    """Create tables and seed the database from the source dataset if empty."""
+
+    Base.metadata.create_all(bind=engine)
+
+    if not IS_SQLITE:
+        # Assume external databases are already provisioned; avoid auto-seeding.
+        return
+
+    dataset = list(_load_dataset())
+    if not dataset:
+        return
+
+    with SessionLocal() as session:
+        has_rows = session.query(Gene).first() is not None
+        if has_rows:
+            return
+
+        session.add_all(dataset)
+        session.commit()
+
+
+__all__ = [
+    "Base",
+    "Gene",
+    "SessionLocal",
+    "engine",
+    "init_db",
+]

--- a/docs/aws-deployment.md
+++ b/docs/aws-deployment.md
@@ -1,0 +1,133 @@
+# AWS deployment guide
+
+This guide outlines a production-ready path for deploying the Chromosome 21 Gene
+API to AWS following common industry practices. Although the application uses a
+local SQLite database for convenience, the recommended production architecture
+replaces SQLite with a managed relational database such as Amazon Aurora Serverless
+(MySQL/PostgreSQL compatible) to guarantee durability and scalability.
+
+## 1. Recommended architecture
+
+```
+API Gateway (REST) -> AWS Lambda (FastAPI via Mangum) -> Amazon RDS/Aurora
+                                      |-> Amazon CloudWatch Logs & Metrics
+                                      |-> AWS X-Ray (optional tracing)
+```
+
+Additional services:
+
+- **Amazon S3** for storing deployment artifacts.
+- **AWS Secrets Manager** for database credentials and API secrets.
+- **Amazon VPC** with private subnets for database access and optional VPC
+  connectivity from Lambda (via VPC configuration) if using an RDS instance.
+
+## 2. Infrastructure as Code (IaC)
+
+Use AWS SAM or AWS CDK to manage infrastructure. Below is a minimal SAM template
+snippet defining API Gateway, Lambda, and environment variables:
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Chromosome 21 Gene API
+
+Globals:
+  Function:
+    Runtime: python3.10
+    Timeout: 30
+    MemorySize: 512
+    Tracing: Active
+    Environment:
+      Variables:
+        DATABASE_URL: postgresql+psycopg2://{username}:{password}@{host}:{port}/{db}
+
+Resources:
+  GeneApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: aws_lambda.handler
+      CodeUri: ./build
+      Events:
+        ApiGateway:
+          Type: Api
+          Properties:
+            Path: /{proxy+}
+            Method: ANY
+```
+
+Adjust `DATABASE_URL` for your chosen engine. Store the actual credentials in
+Secrets Manager and inject them using SAM/CloudFormation parameters.
+
+## 3. Build & packaging pipeline
+
+1. **Continuous Integration (CI):**
+   - Run unit tests (`pytest`), linting, and type checks on each commit.
+   - Build the deployment artifact using Docker to ensure parity with Lambda's
+     Amazon Linux runtime.
+
+2. **Artifact packaging:**
+   ```bash
+   sam build --use-container
+   sam package --s3-bucket <artifact-bucket> --output-template-file packaged.yaml
+   ```
+
+3. **Continuous Deployment (CD):**
+   - Deploy to staging using `sam deploy --template-file packaged.yaml`.
+   - Promote to production via approval workflows in your CI/CD tool (GitHub
+     Actions, AWS CodePipeline, GitLab CI, etc.).
+
+## 4. Database migration strategy
+
+1. Use SQLAlchemy's Alembic migrations to manage schema changes.
+2. Run migrations as part of your deployment pipeline (e.g., a one-off Lambda or
+   AWS Step Functions task prior to shifting traffic).
+3. Seed data by running a separate job that loads the mart export into the RDS
+   instance using the same logic as `database.init_db`, adjusted for the managed
+   database connection string.
+
+## 5. Observability & operations
+
+- **Logging:** CloudWatch Logs is automatically populated by Lambda. Configure
+  structured logging for easier analysis.
+- **Metrics:** Use CloudWatch metrics and alarms for error rates, latency, and
+  throttling. Consider creating custom metrics for query counts or dataset size.
+- **Tracing:** Enable AWS X-Ray for distributed tracing across API Gateway and
+  Lambda.
+- **Dashboards:** Build CloudWatch dashboards or integrate with third-party
+  observability platforms (Datadog, New Relic) as needed.
+
+## 6. Security best practices
+
+- Enforce least-privilege IAM roles for Lambda (access only to Secrets Manager,
+  CloudWatch, and database resources required).
+- Rotate credentials stored in Secrets Manager regularly.
+- Enable AWS WAF on API Gateway for protection against common web attacks.
+- Require HTTPS only and configure throttling/quotas on API Gateway.
+- Use AWS Shield Advanced if compliance or threat models require it.
+
+## 7. Cost optimisation tips
+
+- Use provisioned concurrency only for latency-sensitive production traffic; rely
+  on on-demand for lower environments.
+- Choose Aurora Serverless v2 or RDS with autoscaling to adapt to load patterns.
+- Set CloudWatch alarms to detect anomalous cost spikes.
+
+## 8. Local parity & testing
+
+- Use Docker Compose with LocalStack to emulate AWS services for integration
+  tests.
+- Run contract tests against staging endpoints before promoting to production.
+- Version your OpenAPI specification and share with consumers to prevent breaking
+  changes.
+
+## 9. Deployment checklist
+
+- [ ] OpenAPI spec updated and communicated to API consumers.
+- [ ] Database migrations applied.
+- [ ] Lambda artifact built and uploaded to S3.
+- [ ] Infrastructure stack deployed via SAM/CDK.
+- [ ] Smoke tests executed against staging.
+- [ ] Monitoring and alarms validated.
+
+Following these practices will help ensure the API is secure, observable, and
+scalable when deployed on AWS.

--- a/main.py
+++ b/main.py
@@ -1,41 +1,117 @@
-from fastapi import FastAPI, HTTPException
-from typing import List, Dict, Any
-import pandas as pd
-from pathlib import Path
+from __future__ import annotations
 
-app = FastAPI(title="Chromosome 21 Gene API")
+from typing import Generator, List, Optional
 
-# Path to your local gene data file
-DATA_FILE = Path(__file__).with_name("mart_export(3).txt")
+from fastapi import Depends, FastAPI, HTTPException, Query
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
 
-# Load gene data
-def load_genes() -> pd.DataFrame:
-    return pd.read_csv(DATA_FILE)
+from database import Gene, SessionLocal, init_db
+from pydantic import BaseModel
+
+app = FastAPI(title="Chromosome 21 Gene API", version="2.0.0")
+
+
+class GeneRead(BaseModel):
+    gene_stable_id: str
+    gene_name: Optional[str]
+    gene_description: Optional[str]
+    chromosome: Optional[str]
+    gene_start: Optional[int]
+    gene_end: Optional[int]
+    strand: Optional[int]
+    gene_type: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class GeneListResponse(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    items: List[GeneRead]
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    """Ensure the SQLite database is initialised before serving requests."""
+
+    init_db()
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 @app.get("/")
-def root():
+def root() -> dict[str, str]:
     return {"message": "Welcome to Chromosome 21 Gene API"}
 
-@app.get("/genes", response_model=List[Dict[str, Any]])
-def list_genes() -> List[Dict[str, Any]]:
-    df = load_genes().copy()
-    df = df.where(pd.notnull(df), None)  # Replace NaN/NaT with None
-    return df.to_dict(orient="records")
 
-@app.get("/genes/{gene_name}", response_model=Dict[str, Any])
-def get_gene_by_name(gene_name: str) -> Dict[str, Any]:
-    df = load_genes().copy()
-    df = df.where(pd.notnull(df), None)
+@app.get("/genes", response_model=GeneListResponse)
+def list_genes(
+    page: int = Query(1, ge=1, description="Page number (1-indexed)."),
+    page_size: int = Query(
+        25,
+        ge=1,
+        le=200,
+        description="Number of genes to return per page (max 200).",
+    ),
+    chromosome: Optional[str] = Query(
+        None, description="Filter genes by chromosome/scaffold name."
+    ),
+    gene_type: Optional[str] = Query(None, description="Filter genes by gene type."),
+    search: Optional[str] = Query(
+        None,
+        description="Case-insensitive search across gene name and description.",
+    ),
+    db: Session = Depends(get_db),
+) -> GeneListResponse:
+    query = db.query(Gene)
 
-    # Detect correct column name for gene name
-    if "Gene name" in df.columns:
-        name_col = "Gene name"
-    elif "gene_name" in df.columns:
-        name_col = "gene_name"
-    else:
-        raise HTTPException(status_code=500, detail="Dataset missing gene name column")
+    if chromosome:
+        query = query.filter(Gene.chromosome == chromosome)
+    if gene_type:
+        query = query.filter(Gene.gene_type.ilike(f"%{gene_type}%"))
+    if search:
+        like_pattern = f"%{search}%"
+        query = query.filter(
+            or_(Gene.gene_name.ilike(like_pattern), Gene.gene_description.ilike(like_pattern))
+        )
 
-    match = df[df[name_col].fillna("").str.lower() == gene_name.lower()]
-    if match.empty:
+    total = query.count()
+    items = (
+        query.order_by(Gene.gene_start)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return GeneListResponse(total=total, page=page, page_size=page_size, items=items)
+
+
+@app.get("/genes/{gene_stable_id}", response_model=GeneRead)
+def get_gene(gene_stable_id: str, db: Session = Depends(get_db)) -> GeneRead:
+    gene = db.get(Gene, gene_stable_id)
+    if gene is None:
         raise HTTPException(status_code=404, detail="Gene not found")
-    return match.to_dict(orient="records")[0]
+    return gene
+
+
+@app.get("/genes/by-name/{gene_name}", response_model=GeneRead)
+def get_gene_by_name(gene_name: str, db: Session = Depends(get_db)) -> GeneRead:
+    gene = (
+        db.query(Gene)
+        .filter(Gene.gene_name.is_not(None))
+        .filter(Gene.gene_name.ilike(gene_name))
+        .order_by(Gene.gene_start)
+        .first()
+    )
+    if gene is None:
+        raise HTTPException(status_code=404, detail="Gene not found")
+    return gene

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.99.0
 mangum
-pandas
+sqlalchemy>=1.4,<2.0
 uvicorn


### PR DESCRIPTION
## Summary
- replace the in-memory pandas workflow with a SQLAlchemy-powered SQLite database and provide RESTful pagination and filtering endpoints
- wire the FastAPI app and Lambda handler to the new database initialisation routine and expose a typed response schema
- document local usage, configuration, and AWS best-practice deployment guidance

## Testing
- not run (unable to install dependencies in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ddb29871d083328f534a9fd8e6ceb8